### PR TITLE
Refactored AST nodes for object properties

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ast/AbstractObjectProperty.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/AbstractObjectProperty.java
@@ -1,0 +1,16 @@
+package org.mozilla.javascript.ast;
+
+/** Property of an object literal. */
+public abstract class AbstractObjectProperty extends AstNode {
+    protected AbstractObjectProperty() {
+        super();
+    }
+
+    protected AbstractObjectProperty(int pos) {
+        super(pos);
+    }
+
+    protected AbstractObjectProperty(int pos, int len) {
+        super(pos, len);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ast/ObjectLiteral.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/ObjectLiteral.java
@@ -31,10 +31,10 @@ import org.mozilla.javascript.Token;
  */
 public class ObjectLiteral extends AstNode implements DestructuringForm {
 
-    private static final List<ObjectProperty> NO_ELEMS =
+    private static final List<AbstractObjectProperty> NO_ELEMS =
             Collections.unmodifiableList(new ArrayList<>());
 
-    private List<ObjectProperty> elements;
+    private List<AbstractObjectProperty> elements;
     boolean isDestructuring;
 
     {
@@ -52,7 +52,7 @@ public class ObjectLiteral extends AstNode implements DestructuringForm {
     }
 
     /** Returns the element list. Returns an immutable empty list if there are no elements. */
-    public List<ObjectProperty> getElements() {
+    public List<AbstractObjectProperty> getElements() {
         return elements != null ? elements : NO_ELEMS;
     }
 
@@ -62,12 +62,12 @@ public class ObjectLiteral extends AstNode implements DestructuringForm {
      *
      * @param elements the element list. Can be {@code null}.
      */
-    public void setElements(List<ObjectProperty> elements) {
+    public void setElements(List<AbstractObjectProperty> elements) {
         if (elements == null) {
             this.elements = null;
         } else {
             if (this.elements != null) this.elements.clear();
-            for (ObjectProperty o : elements) addElement(o);
+            for (AbstractObjectProperty o : elements) addElement(o);
         }
     }
 
@@ -77,7 +77,7 @@ public class ObjectLiteral extends AstNode implements DestructuringForm {
      * @param element the property node to append to the end of the list
      * @throws IllegalArgumentException} if element is {@code null}
      */
-    public void addElement(ObjectProperty element) {
+    public void addElement(AbstractObjectProperty element) {
         assertNotNull(element);
         if (elements == null) {
             elements = new ArrayList<>();
@@ -112,7 +112,7 @@ public class ObjectLiteral extends AstNode implements DestructuringForm {
         if (elements != null) {
             int i = 0;
             sb.append("\n");
-            for (AstNode element : elements) {
+            for (AbstractObjectProperty element : elements) {
                 sb.append(element.toSource(depth));
                 if (sb.charAt(sb.length() - 1) == '\n') {
                     sb.deleteCharAt(sb.length() - 1);
@@ -132,7 +132,7 @@ public class ObjectLiteral extends AstNode implements DestructuringForm {
     @Override
     public void visit(NodeVisitor v) {
         if (v.visit(this)) {
-            for (ObjectProperty prop : getElements()) {
+            for (AbstractObjectProperty prop : getElements()) {
                 prop.visit(v);
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ast/Spread.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/Spread.java
@@ -8,7 +8,7 @@ package org.mozilla.javascript.ast;
 
 import org.mozilla.javascript.Token;
 
-/** AST node for a spread key, i.e. `...expression` in an object literal. */
+/** AST node for a spread `...expression`. */
 public class Spread extends AstNode {
 
     private AstNode expression;

--- a/rhino/src/main/java/org/mozilla/javascript/ast/SpreadObjectProperty.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ast/SpreadObjectProperty.java
@@ -1,0 +1,47 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.ast;
+
+import org.mozilla.javascript.Token;
+
+/** AST node for a spread `...expression` in an object literal. */
+public class SpreadObjectProperty extends AbstractObjectProperty {
+
+    private final Spread spreadNode;
+
+    {
+        type = Token.DOTDOTDOT;
+    }
+
+    public SpreadObjectProperty(Spread spreadNode) {
+        super(spreadNode.getPosition(), spreadNode.getLength());
+        this.spreadNode = spreadNode;
+        this.spreadNode.setParent(this);
+        this.setLineColumnNumber(spreadNode.getLineno(), spreadNode.getColumn());
+    }
+
+    public Spread getSpreadNode() {
+        return spreadNode;
+    }
+
+    @Override
+    public boolean hasSideEffects() {
+        return spreadNode.hasSideEffects();
+    }
+
+    @Override
+    public String toSource(int depth) {
+        return spreadNode.toSource(depth);
+    }
+
+    @Override
+    public void visit(NodeVisitor v) {
+        if (v.visit(this)) {
+            spreadNode.visit(v);
+        }
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserLineColumnNumberTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserLineColumnNumberTest.java
@@ -47,6 +47,7 @@ import org.mozilla.javascript.ast.RegExpLiteral;
 import org.mozilla.javascript.ast.ReturnStatement;
 import org.mozilla.javascript.ast.Scope;
 import org.mozilla.javascript.ast.Spread;
+import org.mozilla.javascript.ast.SpreadObjectProperty;
 import org.mozilla.javascript.ast.StringLiteral;
 import org.mozilla.javascript.ast.SwitchCase;
 import org.mozilla.javascript.ast.SwitchStatement;
@@ -912,47 +913,48 @@ class ParserLineColumnNumberTest {
         ObjectProperty propA =
                 assertInstanceOf(ObjectProperty.class, objectLiteral.getElements().get(0));
         assertLineColumnAre(propA, 0, 7);
-        assertLineColumnAre(propA.getLeft(), 0, 7);
-        assertLineColumnAre(propA.getRight(), 0, 10);
+        assertLineColumnAre(propA.getKey(), 0, 7);
+        assertLineColumnAre(propA.getValue(), 0, 10);
 
         ObjectProperty propB =
                 assertInstanceOf(ObjectProperty.class, objectLiteral.getElements().get(1));
         assertLineColumnAre(propB, 1, 2);
-        ComputedPropertyKey propBKey = assertInstanceOf(ComputedPropertyKey.class, propB.getLeft());
+        AstNode result = propB.getKey();
+        ComputedPropertyKey propBKey = assertInstanceOf(ComputedPropertyKey.class, result);
         assertLineColumnAre(propBKey, 1, 2);
         assertLineColumnAre(propBKey.getExpression(), 1, 3);
-        assertLineColumnAre(propB.getRight(), 1, 7);
+        assertLineColumnAre(propB.getValue(), 1, 7);
 
         ObjectProperty propC =
                 assertInstanceOf(ObjectProperty.class, objectLiteral.getElements().get(2));
         assertLineColumnAre(propC, 2, 2);
-        assertLineColumnAre(propC.getLeft(), 2, 2);
-        assertLineColumnAre(propC.getRight(), 2, 2);
+        assertLineColumnAre(propC.getKey(), 2, 2);
+        assertLineColumnAre(propC.getValue(), 2, 2);
 
         ObjectProperty propD =
                 assertInstanceOf(ObjectProperty.class, objectLiteral.getElements().get(3));
         assertLineColumnAre(propD, 3, 2);
-        assertLineColumnAre(propD.getLeft(), 3, 2);
-        assertLineColumnAre(propD.getRight(), 3, 5);
+        assertLineColumnAre(propD.getKey(), 3, 2);
+        assertLineColumnAre(propD.getValue(), 3, 5);
 
         ObjectProperty propE =
                 assertInstanceOf(ObjectProperty.class, objectLiteral.getElements().get(4));
         assertLineColumnAre(propE, 4, 2);
-        assertLineColumnAre(propE.getLeft(), 4, 2);
-        assertLineColumnAre(propE.getRight(), 4, 6);
+        assertLineColumnAre(propE.getKey(), 4, 2);
+        assertLineColumnAre(propE.getValue(), 4, 6);
 
         ObjectProperty propF =
                 assertInstanceOf(ObjectProperty.class, objectLiteral.getElements().get(5));
         assertLineColumnAre(propF, 5, 2);
-        assertLineColumnAre(propF.getLeft(), 5, 2);
-        assertLineColumnAre(propF.getRight(), 5, 6);
+        assertLineColumnAre(propF.getKey(), 5, 2);
+        assertLineColumnAre(propF.getValue(), 5, 6);
 
-        ObjectProperty propG =
-                assertInstanceOf(ObjectProperty.class, objectLiteral.getElements().get(6));
+        SpreadObjectProperty propG =
+                assertInstanceOf(SpreadObjectProperty.class, objectLiteral.getElements().get(6));
         assertLineColumnAre(propG, 6, 2);
-        assertLineColumnAre(propG.getLeft(), 6, 2);
-        assertLineColumnAre(((Spread) propG.getLeft()).getExpression(), 6, 5);
-        assertNull(propG.getRight());
+        Spread propGSpread = propG.getSpreadNode();
+        assertLineColumnAre(propGSpread, 6, 2);
+        assertLineColumnAre(propGSpread.getExpression(), 6, 5);
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ParserTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.io.IOException;
 import java.util.List;
@@ -22,6 +23,7 @@ import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Node;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.Token;
+import org.mozilla.javascript.ast.AbstractObjectProperty;
 import org.mozilla.javascript.ast.Assignment;
 import org.mozilla.javascript.ast.AstNode;
 import org.mozilla.javascript.ast.AstRoot;
@@ -726,17 +728,17 @@ public class ParserTest {
         Name firstVarName = (Name) firstInitializer.getTarget();
 
         ObjectLiteral objectLiteral = (ObjectLiteral) firstInitializer.getInitializer();
-        List<ObjectProperty> props = objectLiteral.getElements();
-        ObjectProperty firstObjectLit = props.get(0);
-        ObjectProperty secondObjectLit = props.get(1);
-        ObjectProperty thirdObjectLit = props.get(2);
+        List<AbstractObjectProperty> props = objectLiteral.getElements();
+        var firstObjectLit = assertInstanceOf(ObjectProperty.class, props.get(0));
+        var secondObjectLit = assertInstanceOf(ObjectProperty.class, props.get(1));
+        var thirdObjectLit = assertInstanceOf(ObjectProperty.class, props.get(2));
 
-        AstNode firstKey = firstObjectLit.getLeft();
-        AstNode firstValue = firstObjectLit.getRight();
-        AstNode secondKey = secondObjectLit.getLeft();
-        AstNode secondValue = secondObjectLit.getRight();
-        AstNode thirdKey = thirdObjectLit.getLeft();
-        AstNode thirdValue = thirdObjectLit.getRight();
+        AstNode firstKey = firstObjectLit.getKey();
+        AstNode firstValue = firstObjectLit.getValue();
+        AstNode secondKey = secondObjectLit.getKey();
+        AstNode secondValue = secondObjectLit.getValue();
+        AstNode thirdKey = thirdObjectLit.getKey();
+        AstNode thirdValue = thirdObjectLit.getValue();
 
         assertLineColumnAre(1, 5, firstVarName);
         assertLineColumnAre(2, 1, objectLiteral);
@@ -982,7 +984,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        NumberLiteral number = (NumberLiteral) lit.getElements().get(0).getLeft();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        NumberLiteral number = (NumberLiteral) prop.getKey();
         assertNotNull(number.getJsDoc());
     }
 
@@ -994,9 +997,10 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        for (ObjectProperty el : lit.getElements()) {
-            assertNull(el.getLeft().getJsDoc());
-            assertNull(el.getRight().getJsDoc());
+        for (AbstractObjectProperty abstractEl : lit.getElements()) {
+            ObjectProperty el = (ObjectProperty) abstractEl;
+            assertNull(el.getKey().getJsDoc());
+            assertNull(el.getValue().getJsDoc());
         }
     }
 
@@ -1008,7 +1012,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        StringLiteral stringLit = (StringLiteral) lit.getElements().get(0).getLeft();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        StringLiteral stringLit = (StringLiteral) prop.getKey();
         assertNotNull(stringLit.getJsDoc());
     }
 
@@ -1020,8 +1025,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        ParenthesizedExpression parens =
-                (ParenthesizedExpression) lit.getElements().get(0).getRight();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        ParenthesizedExpression parens = (ParenthesizedExpression) prop.getValue();
         assertNotNull(parens.getJsDoc());
     }
 
@@ -1033,7 +1038,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        Name objLitKey = (Name) lit.getElements().get(0).getLeft();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        Name objLitKey = (Name) prop.getKey();
         assertNotNull(objLitKey.getJsDoc());
     }
 
@@ -1045,8 +1051,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        ParenthesizedExpression parens =
-                (ParenthesizedExpression) lit.getElements().get(0).getRight();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        ParenthesizedExpression parens = (ParenthesizedExpression) prop.getValue();
         assertNotNull(parens.getJsDoc());
     }
 
@@ -1058,7 +1064,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        Name objLitKey = (Name) lit.getElements().get(0).getLeft();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        Name objLitKey = (Name) prop.getKey();
         assertNotNull(objLitKey.getJsDoc());
     }
 
@@ -1070,7 +1077,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        NumberLiteral number = (NumberLiteral) lit.getElements().get(0).getLeft();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        NumberLiteral number = (NumberLiteral) prop.getKey();
         assertNotNull(number.getJsDoc());
     }
 
@@ -1082,7 +1090,8 @@ public class ParserTest {
         ExpressionStatement st = (ExpressionStatement) root.getFirstChild();
         ParenthesizedExpression pt = (ParenthesizedExpression) st.getExpression();
         ObjectLiteral lit = (ObjectLiteral) pt.getExpression();
-        StringLiteral stringLit = (StringLiteral) lit.getElements().get(0).getLeft();
+        ObjectProperty prop = (ObjectProperty) lit.getElements().get(0);
+        StringLiteral stringLit = (StringLiteral) prop.getKey();
         assertNotNull(stringLit.getJsDoc());
     }
 
@@ -1455,16 +1464,16 @@ public class ParserTest {
         assertTrue(((Assignment) expr.getExpression()).getRight() instanceof ObjectLiteral);
         ObjectLiteral obj = (ObjectLiteral) ((Assignment) expr.getExpression()).getRight();
         assertEquals(1, obj.getElements().size());
-        ObjectProperty g = obj.getElements().get(0);
+        ObjectProperty g = (ObjectProperty) obj.getElements().get(0);
 
-        assertTrue(g.getLeft() instanceof GeneratorMethodDefinition);
-        assertLineColumnAre(0, 7, g.getLeft());
-        AstNode genMethodName = ((GeneratorMethodDefinition) g.getLeft()).getMethodName();
+        assertTrue(g.getKey() instanceof GeneratorMethodDefinition);
+        assertLineColumnAre(0, 7, g.getKey());
+        AstNode genMethodName = ((GeneratorMethodDefinition) g.getKey()).getMethodName();
         assertTrue(genMethodName instanceof Name);
         assertLineColumnAre(0, 8, genMethodName);
 
-        assertTrue(g.getRight() instanceof FunctionNode);
-        assertTrue(((FunctionNode) g.getRight()).isES6Generator());
+        assertTrue(g.getValue() instanceof FunctionNode);
+        assertTrue(((FunctionNode) g.getValue()).isES6Generator());
     }
 
     @Test


### PR DESCRIPTION
Now we have a base class `AbstractObjectProperty` from which `ObjectProperty` and `SpreadObjectProperty` inherit. There's a bit of noise because I also renamed `left` with `key`, and `right` with `value`, since `ObjectProperty` doesn't inherit from `InfixProperty` anymore. I think the code ends up being cleaner like this.